### PR TITLE
Added config option to toggle html-min usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@ var gulp = require('gulp'),
 elixir.extend('ngTemplateCache', function(src, output, basedir, options) {
 
     options = extend(true, {
+        enabled: {
+            htmlmin: config.production
+        },
         templateCache: {
             standalone: true
         },
@@ -27,7 +30,7 @@ elixir.extend('ngTemplateCache', function(src, output, basedir, options) {
 
         return gulp.src(paths.src.path)
             .pipe(gulpIf(config.sourcemaps, sourcemap.init()))
-            .pipe(gulpIf(config.production, htmlmin(options.htmlmin)))
+            .pipe(gulpIf(options.enabled.hmtlmin, htmlmin(options.htmlmin)))
             .pipe(templateCache(options.templateCache))
             .pipe(gulpIf(config.sourcemaps, sourcemap.write('.')))
             .pipe(gulp.dest(paths.output.baseDir))


### PR DESCRIPTION
Currently it's only possible to minify the output if the production flag is set. Thus it is not possible to add the minification to the development system. As in HTML to have spaces between (block_inline) elements can result in different display results it should be possible to enable the minification manually to also respect this while developing and visually testing the CSS styles outside of the production environment.

The cleanest and most-backward compatible way I could think of is to just add the proposed 'enabled' configuration, which defaults to the current behavior of 'config.production', to toggle filters manually on and off.